### PR TITLE
Update tornado version to 6.5.6 to resolve vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tornado==6.5.5
+tornado==6.5.6
 setuptools==80.9.0
 websocket-client==1.8.0
 mosestokenizer==1.2.1


### PR DESCRIPTION
Resolve CVE-2026-49854 vulnerability in tornado 6.5.5